### PR TITLE
175 Support comfyui-naia-bridge hotfix

### DIFF
--- a/NAIA_cold_v4.py
+++ b/NAIA_cold_v4.py
@@ -2074,6 +2074,21 @@ class ModernMainWindow(QMainWindow):
         sampling_mode_layout.addWidget(self.eps_radio)
         sampling_mode_layout.addWidget(self.v_pred_radio)
         sampling_mode_layout.addWidget(self.anima_radio)
+
+        # ANIMA 가중치 입력 (ANIMA 선택 시만 표시)
+        self.anima_weight_edit = QLineEdit()
+        self.anima_weight_edit.setPlaceholderText("0.75")
+        self.anima_weight_edit.setFixedWidth(get_scaled_size(70))
+        self.anima_weight_edit.setToolTip(
+            "ANIMA 가중치 (기본 0.75)\n"
+            "· 0 또는 1 입력 → 가중치 없음 (블록 래핑 생략)\n"
+            "· 잘못된 값 → 기본값 0.75"
+        )
+        self.anima_weight_edit.setStyleSheet(DARK_STYLES['compact_lineedit'])
+        self.anima_weight_edit.setProperty("autocomplete_ignore", True)
+        self.anima_weight_edit.setVisible(False)
+        sampling_mode_layout.addWidget(self.anima_weight_edit)
+
         sampling_mode_layout.addStretch()
 
         self.sampling_mode_group.buttonClicked.connect(self._on_sampling_mode_changed)
@@ -2469,6 +2484,8 @@ class ModernMainWindow(QMainWindow):
                 w.setVisible(True)
             for w in self.comfyui_rescale_ui:
                 w.setVisible(False)
+            if hasattr(self, 'anima_weight_edit'):
+                self.anima_weight_edit.setVisible(False)
 
             # 🆕 임시 창 자동 종료 체크
             old_mode = self._previous_api_mode
@@ -2549,6 +2566,8 @@ class ModernMainWindow(QMainWindow):
                                 w.setVisible(False)
                             for w in self.comfyui_rescale_ui:
                                 w.setVisible(False)
+                            if hasattr(self, 'anima_weight_edit'):
+                                self.anima_weight_edit.setVisible(False)
 
                             self.status_bar.showMessage(f"✅ WEBUI 모드로 전환되었습니다. ({validated_url})", 5000)
 
@@ -2676,6 +2695,8 @@ class ModernMainWindow(QMainWindow):
                             is_anima = hasattr(self, 'anima_radio') and self.anima_radio.isChecked()
                             for w in self.comfyui_rescale_ui:
                                 w.setVisible(is_anima)
+                            if hasattr(self, 'anima_weight_edit'):
+                                self.anima_weight_edit.setVisible(is_anima)
 
                             self.status_bar.showMessage(f"✅ ComfyUI 모드로 전환되었습니다. ({comfyui_url})", 5000)
 
@@ -2910,6 +2931,12 @@ class ModernMainWindow(QMainWindow):
                     # ANIMA 모드: Rescale CFG 값 추가
                     if workflow_type == "unet" and hasattr(self, 'comfyui_rescale_slider'):
                         params["rescale_cfg"] = self.comfyui_rescale_slider.value() / 100.0
+
+                    # ANIMA 모드: 사용자 지정 가중치 (공란/잘못된 값 → prompt_processor 가 기본값 0.75 로 복원)
+                    if sampling_mode == "anima" and hasattr(self, 'anima_weight_edit'):
+                        raw = self.anima_weight_edit.text().strip()
+                        if raw:
+                            params["anima_weight"] = raw
 
                     # 디버그 정보
                     print(f"🎨 ComfyUI 파라미터 수집 완료:")
@@ -6202,12 +6229,14 @@ class ModernMainWindow(QMainWindow):
             self.status_bar.showMessage("🔄 기본 워크플로우로 전환되었습니다.", 3000)
 
     def _on_sampling_mode_changed(self, button):
-        """ComfyUI 샘플링 모드 변경 시 Rescale CFG 가시성 제어"""
+        """ComfyUI 샘플링 모드 변경 시 Rescale CFG / ANIMA 가중치 입력 가시성 제어"""
         is_anima = (button == self.anima_radio)
         # ComfyUI 모드일 때만 Rescale CFG 표시/숨김 처리
         if self.get_current_api_mode() == "COMFYUI":
             for w in self.comfyui_rescale_ui:
                 w.setVisible(is_anima)
+            if hasattr(self, 'anima_weight_edit'):
+                self.anima_weight_edit.setVisible(is_anima)
 
     def on_generate_with_image_requested(self, tags_dict: dict):
         """WebView에서 추출된 태그로 프롬프트를 생성하고 바로 이미지 생성을 시작합니다."""

--- a/core/prompt_processor.py
+++ b/core/prompt_processor.py
@@ -1,3 +1,4 @@
+import math
 import re
 import pandas as pd
 from typing import Dict, Any
@@ -55,6 +56,33 @@ def _find_weighted_indices(tags: list, start: int) -> set:
                 weighted.add(i)
 
     return weighted
+
+
+def _parse_anima_weight(raw) -> tuple[bool, float]:
+    """ANIMA 가중치 입력값 파싱.
+
+    Returns:
+        (skip_block, weight):
+            - skip_block=True → 괄호 래핑 자체를 생략 (가중치 없음)
+            - skip_block=False → weight 를 `:{weight})` 로 적용
+    규칙:
+        - None / 공란 → 기본값 0.75 사용
+        - 0 또는 1 → skip_block=True (래핑 생략)
+        - 잘못된 값 → 기본값 0.75 로 복원 (입력 무시)
+    """
+    DEFAULT = 0.75
+    if raw is None:
+        return (False, DEFAULT)
+    try:
+        value = float(str(raw).strip())
+    except (ValueError, TypeError):
+        return (False, DEFAULT)
+    if not math.isfinite(value):
+        # nan / inf / -inf → 잘못된 값으로 취급, 기본값 복원
+        return (False, DEFAULT)
+    if value == 0.0 or value == 1.0:
+        return (True, value)
+    return (False, value)
 
 
 def _escape_main_tags_parens(tags: list, weighted: set):
@@ -226,6 +254,15 @@ class PromptProcessor:
         is_comfyui = self.app_context.current_api_mode == 'COMFYUI'
 
         if is_comfyui and is_anima_mode:
+            # ANIMA 가중치 — 사용자 설정값 (없거나 잘못되면 0.75, 0/1 이면 래핑 생략)
+            # 우선순위: context.settings > main_window.anima_weight_edit (Interactive/Remote 폴백)
+            raw_anima_weight = context.settings.get('anima_weight')
+            if raw_anima_weight is None and hasattr(self.app_context, 'main_window'):
+                mw = self.app_context.main_window
+                if hasattr(mw, 'anima_weight_edit'):
+                    raw_anima_weight = mw.anima_weight_edit.text().strip() or None
+            anima_skip, anima_weight = _parse_anima_weight(raw_anima_weight)
+
             # ANIMA 모드: @ 태그 앞에 삽입
             at_index = None
             for i, tag in enumerate(context.prefix_tags):
@@ -250,11 +287,10 @@ class PromptProcessor:
                         # 괄호 이스케이프 처리
                         char_list = [c.replace("(", r"\(").replace(")", r"\)") for c in char_list]
 
-                        # 첫 원소에 "(" 붙이기
-                        char_list[0] = f"({char_list[0]}"
-
-                        # 마지막 원소에 ":0.8)" 붙이기
-                        char_list[-1] = f"{char_list[-1]}:0.7)"
+                        # 가중치 래핑 (anima_weight — 0/1 또는 잘못된 입력은 _parse_anima_weight 에서 처리)
+                        if not anima_skip:
+                            char_list[0] = f"({char_list[0]}"
+                            char_list[-1] = f"{char_list[-1]}:{anima_weight})"
 
                         # 다시 쉼표로 조인
                         character = ', '.join(char_list)
@@ -294,11 +330,10 @@ class PromptProcessor:
                         # 괄호 이스케이프 처리
                         char_list = [c.replace("(", r"\(").replace(")", r"\)") for c in char_list]
 
-                        # 첫 원소에 "(" 붙이기
-                        char_list[0] = f"({char_list[0]}"
-
-                        # 마지막 원소에 ":0.8)" 붙이기
-                        char_list[-1] = f"{char_list[-1]}:0.75)"
+                        # 가중치 래핑 (anima_weight — 0/1 또는 잘못된 입력은 _parse_anima_weight 에서 처리)
+                        if not anima_skip:
+                            char_list[0] = f"({char_list[0]}"
+                            char_list[-1] = f"{char_list[-1]}:{anima_weight})"
 
                         # 다시 쉼표로 조인
                         character = ', '.join(char_list)
@@ -317,10 +352,11 @@ class PromptProcessor:
                 context.prefix_tags = context.prefix_tags + anima_tags
                 print(f"🎨 ANIMA 모드: @ 태그 없음, 태그를 맨 뒤에 삽입: {', '.join(anima_tags)}")
 
-            # 🆕 ANIMA 모드: main_tags에 가중치 적용 (0.75)
+            # 🆕 ANIMA 모드: main_tags에 가중치 적용 (사용자 지정, 기본 0.75)
             # 이미 가중치가 적용된 태그(Danbooru/e621)는 제외하고 비가중치 연속 구간만 래핑
             # weighted_indices는 4-0 단계에서 이미 계산됨 (이스케이프 후에도 유효)
-            if context.main_tags and first_non_hash < len(context.main_tags):
+            # anima_skip(0 또는 1)인 경우 래핑 자체를 생략
+            if context.main_tags and first_non_hash < len(context.main_tags) and not anima_skip:
                 # 비가중치 태그의 연속 구간(run) 찾기
                 runs = []
                 run_start = None
@@ -335,12 +371,14 @@ class PromptProcessor:
                 if run_start is not None:
                     runs.append((run_start, len(context.main_tags) - 1))
 
-                # 각 연속 구간을 개별 0.75 그룹으로 래핑
+                # 각 연속 구간을 개별 가중치 그룹으로 래핑
                 for start, end in runs:
                     context.main_tags[start] = f"({context.main_tags[start]}"
-                    context.main_tags[end] = f"{context.main_tags[end]}:0.75)"
+                    context.main_tags[end] = f"{context.main_tags[end]}:{anima_weight})"
 
-                print(f"🎨 ANIMA 모드: main_tags 가중치 0.75 적용 — {len(runs)}개 구간, 가중치 태그 {len(weighted_indices)}개 제외")
+                print(f"🎨 ANIMA 모드: main_tags 가중치 {anima_weight} 적용 — {len(runs)}개 구간, 가중치 태그 {len(weighted_indices)}개 제외")
+            elif context.main_tags and first_non_hash < len(context.main_tags) and anima_skip:
+                print(f"🎨 ANIMA 모드: main_tags 가중치 입력 {context.settings.get('anima_weight')} → 래핑 생략")
 
         else:
             # 기존 방식: 맨 앞에 삽입

--- a/utils/load_generation_params.py
+++ b/utils/load_generation_params.py
@@ -206,6 +206,13 @@ class GenerationParamsManager:
             if hasattr(mw, 'comfyui_rescale_slider') and mw.comfyui_rescale_slider:
                 settings["comfyui_rescale_cfg"] = mw.comfyui_rescale_slider.value() / 100.0
 
+            # ANIMA 가중치 — ANIMA 모드 선택 + 비공란일 때만 저장
+            if (hasattr(mw, 'anima_radio') and mw.anima_radio.isChecked()
+                    and hasattr(mw, 'anima_weight_edit')):
+                text = mw.anima_weight_edit.text().strip()
+                if text:
+                    settings["anima_weight"] = text
+
             # WEBUI 전용 파라미터 수집
             if hasattr(mw, 'enable_hr_checkbox'):
                 settings["enable_hr"] = mw.enable_hr_checkbox.isChecked()
@@ -294,6 +301,7 @@ class GenerationParamsManager:
             # ComfyUI 샘플링 모드 (eps, v_prediction, anima)
             "sampling_mode": "eps",
             "comfyui_rescale_cfg": 0.7,
+            "anima_weight": "",  # ANIMA 모드 전용, 공란 → prompt_processor 기본값 0.75
             
             # 기타 체크박스들
             "random_resolution_checked": False,
@@ -458,12 +466,18 @@ class GenerationParamsManager:
                 rescale_value = float(settings.get("comfyui_rescale_cfg", 0.7))
                 mw.comfyui_rescale_slider.setValue(int(rescale_value * 100))
 
-            # Rescale CFG 가시성: setChecked는 buttonClicked을 발생시키지 않으므로 수동 처리
+            # ANIMA 가중치 값 복원 (ANIMA 모드에서만 의미, 그 외 모드에서는 위젯이 숨김이라 무해)
+            if hasattr(mw, 'anima_weight_edit'):
+                mw.anima_weight_edit.setText(str(settings.get("anima_weight", "")))
+
+            # Rescale CFG / ANIMA 가중치 가시성: setChecked는 buttonClicked을 발생시키지 않으므로 수동 처리
+            is_comfyui = (mw.get_current_api_mode() == "COMFYUI") if hasattr(mw, 'get_current_api_mode') else False
+            is_anima = hasattr(mw, 'anima_radio') and mw.anima_radio.isChecked()
             if hasattr(mw, 'comfyui_rescale_ui'):
-                is_comfyui = (mw.get_current_api_mode() == "COMFYUI") if hasattr(mw, 'get_current_api_mode') else False
-                is_anima = hasattr(mw, 'anima_radio') and mw.anima_radio.isChecked()
                 for w in mw.comfyui_rescale_ui:
                     w.setVisible(is_comfyui and is_anima)
+            if hasattr(mw, 'anima_weight_edit'):
+                mw.anima_weight_edit.setVisible(is_comfyui and is_anima)
             
             print(f"✅ 생성 파라미터 UI 적용 완료")
             


### PR DESCRIPTION
ANIMA 모드 가중치를 사용자 입력으로 제어 가능하도록 확장. 기존 하드코딩 0.7/0.75 (캐릭터 블록 경로 불일치 포함) 를 단일 입력으로 일관화.

- NAIA_cold_v4.py: ANIMA 라디오 옆 QLineEdit 추가. ComfyUI+ANIMA 선택 시만 표시, autocomplete 제외. get_main_parameters 에서 sampling_mode=anima 일 때만 params["anima_weight"] 주입.
- core/prompt_processor.py: _parse_anima_weight 헬퍼 (None/공란/invalid/nan/inf → 기본 0.75, 0 또는 1 → 래핑 전체 생략). 캐릭터 블록 2 경로 + main_tags 연속 구간 3 군데 하드코딩 제거. context.settings 누락 시 main_window.anima_weight_edit 폴백 (Interactive/Remote 공통 경로).
- utils/load_generation_params.py: ANIMA 라디오 ON + 비공란일 때만 generation_params_COMFYUI.json 에 영속화. apply_settings 에서 복원 + setChecked 가 buttonClicked 을 발화시키지 않는 문제 때문에 rescale_cfg 와 함께 가시성 수동 동기화.