### PR TITLE
Add NAI streaming preview (generate-image-stream) with on/off option

### DIFF
--- a/app/backend/server/generation_runner.py
+++ b/app/backend/server/generation_runner.py
@@ -14,7 +14,7 @@ from app.backend.server.generation_commands import (
     random_service,
 )
 from app.backend.server.prompt_tools_routes import save_prompt_engineering_thumbnail_bytes
-from app.backend.server.websocket_broadcast import broadcast_image, broadcast_json
+from app.backend.server.websocket_broadcast import broadcast_image, broadcast_json, broadcast_preview_image
 from core import result_image_payload_service as result_images
 from core.web_session_context import WebSessionContext
 
@@ -135,11 +135,33 @@ async def _run_automation_timer_watcher(context: WebSessionContext, clients: set
         context.automation_timer_watcher_task = None
 
 
+def _make_nai_preview_callback(clients: set[WebSocket], loop: asyncio.AbstractEventLoop):
+    """워커 스레드(asyncio.to_thread)에서 호출되는 NAI 스트리밍 프리뷰 콜백을 만든다.
+
+    콜백은 동기 함수지만 WebSocket 브로드캐스트는 코루틴이므로,
+    ``run_coroutine_threadsafe``로 메인 이벤트 루프에 넘긴다(스레드 안전).
+    프레임은 fire-and-forget으로 전송한다(워커 블로킹 방지).
+    """
+    def _cb(image_bytes: bytes, step, total) -> None:
+        try:
+            info = {"step": int(step), "total": int(total)}
+        except Exception:
+            info = {}
+        try:
+            asyncio.run_coroutine_threadsafe(
+                broadcast_preview_image(clients, image_bytes, info), loop
+            )
+        except Exception:
+            pass
+    return _cb
+
+
 async def run_generation_queue(context: WebSessionContext, clients: set[WebSocket]) -> None:
     if getattr(context, "headless_generation_runner_active", False):
         return
     context.headless_generation_runner_active = True
     try:
+        loop = asyncio.get_running_loop()
         while True:
             request = await asyncio.to_thread(context.generation_queue_manager.dequeue_request)
             if request is None:
@@ -147,8 +169,19 @@ async def run_generation_queue(context: WebSessionContext, clients: set[WebSocke
             context.is_generating = True
             await broadcast_json(clients, {"type": "status", "is_generating": True, "message": "generating"})
             await broadcast_json(clients, context.queue_state_payload())
+            # 🎬 NAI 스트리밍 미리보기: 옵션이 켜져 있고 NAI 모드일 때만 프리뷰 콜백 연결
+            preview_callback = None
             try:
-                stored = await asyncio.to_thread(generation_service(context).execute_request, request)
+                streaming_on = bool(context.remote_options.get("nai_streaming_preview", False))
+            except Exception:
+                streaming_on = False
+            if streaming_on and (getattr(request, "params", {}) or {}).get("api_mode") == "NAI":
+                preview_callback = _make_nai_preview_callback(clients, loop)
+            try:
+                stored = await asyncio.to_thread(
+                    generation_service(context).execute_request, request,
+                    preview_callback,
+                )
             except Exception as exc:
                 await _broadcast_generation_error(context, clients, request, str(exc))
                 continue

--- a/app/backend/server/websocket_broadcast.py
+++ b/app/backend/server/websocket_broadcast.py
@@ -29,3 +29,21 @@ async def broadcast_image(clients: set[WebSocket], webp_bytes: bytes, metadata: 
             dead.append(client)
     for client in dead:
         clients.discard(client)
+
+
+async def broadcast_preview_image(clients: set[WebSocket], image_bytes: bytes, info: dict[str, Any]) -> None:
+    """NAI 스트리밍 중간 프리뷰 프레임을 브로드캐스트한다.
+
+    프론트엔드는 ``nai_preview_meta`` 메시지를 받으면 다음에 오는 바이너리 blob을
+    '최종 결과'가 아닌 '중간 프리뷰'로 처리한다(히스토리/완료 처리 없이 뷰어에만 표시).
+    """
+    meta_text = json.dumps({"type": "nai_preview_meta", **info}, ensure_ascii=False)
+    dead = []
+    for client in list(clients):
+        try:
+            await client.send_text(meta_text)
+            await client.send_bytes(image_bytes)
+        except Exception:
+            dead.append(client)
+    for client in dead:
+        clients.discard(client)

--- a/app/web/remote/app.js
+++ b/app/web/remote/app.js
@@ -2023,6 +2023,7 @@ const optBoxes = {
   prompt_fixed: $('optPromptFixed'),
   auto_generate: $('optAutoGen'),
   wildcard_standalone: $('optWcStandalone'),
+  nai_streaming_preview: $('optNaiStreaming'),
 };
 const pendingOptionValues = Object.create(null);
 let translatorPopupRequestId = '';
@@ -2064,7 +2065,34 @@ function initResultInfoResizer() {
 
 // ---- WebSocket ----
 
+// 🎬 NAI 스트리밍: nai_preview_meta 직후 도착하는 blob은 '중간 프리뷰'로 처리한다.
+let nextBlobIsPreview = false;
+let naiPreviewBlobUrl = null;
+
+function handleNaiPreviewBlob(data) {
+  // 중간 프리뷰: 메인 뷰어에 표시만 하고 완료/히스토리/통계 처리는 하지 않는다.
+  try {
+    const url = URL.createObjectURL(data);
+    if (naiPreviewBlobUrl) URL.revokeObjectURL(naiPreviewBlobUrl);
+    naiPreviewBlobUrl = url;
+    preview.src = url;
+    preview.dataset.source = 'preview';
+    preview.classList.add('show');
+    emptyMsg.style.display = 'none';
+  } catch (e) {
+    /* 프리뷰 표시 실패는 무시 (최종 결과에는 영향 없음) */
+  }
+}
+
 function handleWsBlob(data) {
+  // 🎬 NAI 스트리밍 중간 프리뷰 프레임이면 가볍게 표시만 하고 종료
+  if (nextBlobIsPreview) {
+    nextBlobIsPreview = false;
+    handleNaiPreviewBlob(data);
+    return;
+  }
+  // 최종 결과 도착: 남아있는 프리뷰 URL 정리
+  if (naiPreviewBlobUrl) { try { URL.revokeObjectURL(naiPreviewBlobUrl); } catch {} naiPreviewBlobUrl = null; }
   // Live preview: blob → 메인 뷰어에 즉시 표시
   const url = URL.createObjectURL(data);
   if (blobUrl) URL.revokeObjectURL(blobUrl);
@@ -2243,6 +2271,7 @@ function onWsMessageError(error) {
 
 const wsMessageHandlers = {
   image_meta: updateMeta,
+  nai_preview_meta: () => { nextBlobIsPreview = true; },
   status: m => setGen(m.is_generating),
   prompt_generated: updatePromptOnly,
   random_failed: onRandomFailed,

--- a/app/web/remote/index.html
+++ b/app/web/remote/index.html
@@ -637,6 +637,13 @@
         <span class="opt-box" aria-hidden="true"></span>
         <span class="opt-label">WC Solo</span>
       </button>
+      <button type="button" class="opt-toggle" id="optNaiStreaming"
+              data-option="nai_streaming_preview" data-checked="false" aria-pressed="false"
+              data-naia-guide="NAI 스트리밍 미리보기. NovelAI 생성 시 generate-image-stream(SSE)을 사용해 생성 중간 단계 이미지를 메인 뷰어에 실시간으로 표시합니다. NAI 모드 + 기본 생성(txt2img)에서만 동작하며 Anlas 소모량은 동일합니다."
+              onclick="toggleOptionButton('nai_streaming_preview')">
+        <span class="opt-box" aria-hidden="true"></span>
+        <span class="opt-label">NAI Stream</span>
+      </button>
     </div>
     <div class="quick-params">
       <select class="param-select quick-select" id="qResolution" onchange="setParam('resolution',this.value)"></select>

--- a/core/api_service.py
+++ b/core/api_service.py
@@ -305,15 +305,19 @@ class APIService:
         if isinstance(hr_negative, str) and hr_negative.strip():
             payload["hr_negative_prompt"] = hr_negative
 
-    def call_generation_api(self, parameters: Dict[str, Any], progress_callback=None) -> Dict[str, Any]:
+    def call_generation_api(self, parameters: Dict[str, Any], progress_callback=None, preview_callback=None) -> Dict[str, Any]:
         """
         파라미터의 'api_mode'에 따라 적절한 API 호출 메서드로 분기합니다.
         최대 5회까지 예외 발생 시 재시도합니다.
 
         Args:
             parameters: 생성 파라미터
-            progress_callback: ComfyUI 진행률 콜백 (message, current, total, percent)
-                워커 스레드에서 호출되므로 시그널 emit 등 스레드 안전한 방식으로 전달해야 함
+            progress_callback: 진행률 콜백 (message, current, total, percent)
+                ComfyUI 및 NAI 스트리밍에서 사용. 워커 스레드에서 호출되므로
+                스레드 안전한 방식으로 전달해야 함
+            preview_callback: NAI 스트리밍 중간 프리뷰 콜백 (image_bytes, step, total)
+                전달되면 NAI generate-image-stream(SSE)을 사용해 중간 이미지를 받습니다.
+                워커 스레드에서 호출되므로 스레드 안전하게 처리해야 함
         """
         # 입력 프롬프트에서 주석 및 개행문자 처리
         if 'input' in parameters and isinstance(parameters['input'], str):
@@ -453,7 +457,7 @@ class APIService:
                 print(f"[RETRY] 재시도 {attempt}/{max_retries}...")
             try:
                 if api_mode == "NAI":
-                    result = self._call_nai_api(parameters)
+                    result = self._call_nai_api(parameters, progress_callback=progress_callback, preview_callback=preview_callback)
                 elif api_mode == "WEBUI":
                     result = self._call_webui_api(parameters)
                 elif api_mode == "COMFYUI":  # 🆕 새로 추가
@@ -568,8 +572,12 @@ class APIService:
             main_token = self.app_context.secure_token_manager.get_token('nai_token')
             return main_token if main_token else ""
 
-    def _call_nai_api(self, params: Dict[str, Any]) -> Dict[str, Any]:
-        """NovelAI 이미지 생성 API를 호출합니다."""
+    def _call_nai_api(self, params: Dict[str, Any], progress_callback=None, preview_callback=None) -> Dict[str, Any]:
+        """NovelAI 이미지 생성 API를 호출합니다.
+
+        preview_callback이 전달되고 기본 txt2img(generate) 액션이면
+        generate-image-stream(SSE)을 사용해 중간 프리뷰를 스트리밍합니다.
+        """
         try:
             # 🆕 멀티 계정 지원: 라운드 로빈 토큰 선택
             token = self._get_active_nai_token()
@@ -956,6 +964,14 @@ class APIService:
             # 페이로드 직전 지점이 NAI로 나가는 진짜 마지막 단계이므로 여기서 최종 보정한다.
             self._snap_nai_api_parameters_resolution(api_parameters)
 
+            # 🎬 NAI 스트리밍 미리보기 사용 여부 결정
+            # preview_callback이 있고 기본 txt2img(generate) 액션일 때만 스트리밍.
+            # (img2img/infill은 일반 경로로 처리하여 호환성 보장)
+            use_stream = (preview_callback is not None) and action_type == "generate"
+            if use_stream:
+                # stream 파라미터는 parameters 객체 내부에 위치 (SSE)
+                api_parameters["stream"] = "sse"
+
             # 최종 페이로드 구성
             payload = {
                 "input": params.get('input', ''),
@@ -968,12 +984,30 @@ class APIService:
                 "Authorization": f"Bearer {token}",
                 "Content-Type": "application/json"
             }
-            
+
             # print("📤 NAI API 요청 페이로드:", payload)
-            
+
             # API payload를 안전하게 저장
             self.app_context.store_api_payload(payload, "NAI")
-            
+
+            # 🎬 스트리밍 경로: generate-image-stream(SSE)으로 중간 프리뷰 수신 후 최종 이미지 반환
+            if use_stream:
+                steps_for_progress = api_parameters.get('steps', 28)
+                image_bytes = self._stream_nai_request(
+                    payload, headers, steps_for_progress,
+                    progress_callback=progress_callback,
+                    preview_callback=preview_callback,
+                )
+                self._cleanup_http_threads()
+                if not image_bytes:
+                    raise Exception("스트리밍 응답에서 최종 이미지를 받지 못했습니다.")
+                try:
+                    image = Image.open(io.BytesIO(image_bytes))
+                    image.load()
+                except Exception as e:
+                    raise Exception(f"스트리밍 최종 이미지 처리 실패: {e}")
+                return {'status': 'success', 'image': image, 'raw_bytes': image_bytes}
+
             # HTTP 세션을 사용하여 연결 정리
             with requests.Session() as session:
                 response = session.post(
@@ -1291,6 +1325,100 @@ class APIService:
             # 적용된 파라미터들을 로그에 출력 (디버깅용)
             for key, value in custom_params.items():
                 print(f"   - {key}: {value}")
+
+    def _stream_nai_request(self, payload: Dict[str, Any], headers: Dict[str, str], steps: int,
+                            progress_callback=None, preview_callback=None) -> bytes | None:
+        """
+        NovelAI generate-image-stream(SSE) 엔드포인트를 호출합니다.
+
+        - 중간 단계(event_type='intermediate') 프레임은 preview_callback(image_bytes, step, total)으로 전달
+        - 진행률은 progress_callback(message, current, total, percent)으로 전달
+        - 최종(event_type='final') 프레임의 원본 바이트를 반환
+
+        Returns:
+            최종 이미지의 raw bytes (없으면 None)
+        """
+        # NAI_V3_API_URL = ".../ai/generate-image" → ".../ai/generate-image-stream"
+        stream_url = self.NAI_V3_API_URL + "-stream"
+        stream_headers = dict(headers)
+        stream_headers["Accept"] = "text/event-stream"
+
+        final_bytes = None
+        try:
+            steps = int(steps) if steps else 0
+        except Exception:
+            steps = 0
+
+        with requests.Session() as session:
+            response = session.post(
+                stream_url,
+                headers=stream_headers,
+                json=payload,
+                stream=True,
+                timeout=(30, 300),
+            )
+            try:
+                # 오류 응답은 본문을 읽어 예외로 처리 (재시도/에러 표시 일관성)
+                if response.status_code not in (200, 201):
+                    response.raise_for_status()
+
+                for line in response.iter_lines(decode_unicode=True):
+                    if not line:
+                        continue
+                    # SSE 데이터 라인만 처리 (event:/id: 라인은 무시)
+                    if not line.startswith("data:"):
+                        continue
+                    data_str = line[len("data:"):].lstrip()
+                    if not data_str:
+                        continue
+                    try:
+                        event = json.loads(data_str)
+                    except json.JSONDecodeError:
+                        continue
+
+                    event_type = event.get("event_type")
+                    img_b64 = event.get("image")
+                    if not img_b64:
+                        continue
+                    try:
+                        img_bytes = base64.b64decode(img_b64)
+                    except Exception:
+                        continue
+
+                    if event_type == "final":
+                        final_bytes = img_bytes
+                        # 최종 프레임도 즉시 프리뷰에 반영 (완료 처리 전 잔상 방지)
+                        if preview_callback is not None:
+                            try:
+                                preview_callback(img_bytes, steps, steps)
+                            except Exception:
+                                pass
+                    else:
+                        # intermediate 프레임
+                        step_ix = event.get("step_ix", -1)
+                        try:
+                            cur = int(step_ix) + 1 if (step_ix is not None and int(step_ix) >= 0) else 0
+                        except Exception:
+                            cur = 0
+                        if progress_callback is not None and steps > 0:
+                            percent = int(min(max(cur / steps, 0.0), 1.0) * 100)
+                            progress_callback(
+                                f"NAI 스트리밍 : {percent}% ({cur}/{steps})",
+                                cur, steps, percent,
+                            )
+                        if preview_callback is not None:
+                            try:
+                                preview_callback(img_bytes, cur, steps)
+                            except Exception as e:
+                                print(f"⚠️ 스트리밍 프리뷰 콜백 실패: {e}")
+            finally:
+                response.close()
+                if hasattr(session, 'adapters'):
+                    for adapter in session.adapters.values():
+                        if hasattr(adapter, 'poolmanager') and adapter.poolmanager:
+                            adapter.poolmanager.clear()
+
+        return final_bytes
 
     def _process_nai_response(self, content: bytes) -> Dict[str, Any] | None:
         """NAI API의 응답(zip)을 처리하여 PIL Image와 원본 바이트를 반환합니다."""

--- a/core/headless_generation_service.py
+++ b/core/headless_generation_service.py
@@ -201,8 +201,13 @@ class HeadlessGenerationService:
             if key in params
         }
 
-    def execute_request(self, request: GenerationRequest) -> HeadlessStoredResult:
-        """Execute one queued request and store its result in server state."""
+    def execute_request(self, request: GenerationRequest, preview_callback=None, progress_callback=None) -> HeadlessStoredResult:
+        """Execute one queued request and store its result in server state.
+
+        preview_callback/progress_callback: NAI 스트리밍 미리보기용 콜백.
+        제너레이션 러너(asyncio.to_thread)에서 워커 스레드로 호출되므로,
+        콜백 내부에서 이벤트 루프 접근은 스레드 안전하게 처리해야 한다.
+        """
 
         params = dict(request.params or {})
         params["_generation_request"] = request
@@ -217,7 +222,11 @@ class HeadlessGenerationService:
         self._expand_input_wildcards(params)
         request.mark_processing()
         api_service = self._api_service()
-        api_result = api_service.call_generation_api(params)
+        api_result = api_service.call_generation_api(
+            params,
+            progress_callback=progress_callback,
+            preview_callback=preview_callback,
+        )
         if api_result.get("status") == "error":
             error_message = str(api_result.get("message") or "Unknown API error")
             request.mark_failed(error_message)

--- a/core/headless_remote_state_service.py
+++ b/core/headless_remote_state_service.py
@@ -14,6 +14,7 @@ REMOTE_OPTION_DEFAULTS = {
     "auto_generate": False,
     "wildcard_standalone": False,
     "auto_save": True,
+    "nai_streaming_preview": False,
 }
 REMOTE_BOOLEAN_PARAMS = {
     "seed_fixed",


### PR DESCRIPTION
## 개요
NovelAI 생성 시 `generate-image-stream`(SSE)을 사용해 **생성 중간 단계 이미지를 메인 뷰어에 실시간 표시**하는 기능을 추가합니다. 옵션 바의 `NAI Stream` 토글로 on/off 합니다.

## 동작
- `NAI Stream` ON + NAI 모드 + 기본 생성(txt2img)일 때만 스트리밍 사용
- 생성 중 매 스텝의 중간 프레임이 뷰어에 갱신되고, 완료 시 기존 최종 이미지 경로가 덮어쓰며 히스토리에 저장
- img2img/인페인트는 기존 경로 유지, Anlas 소모량 동일

## 변경 사항
**백엔드**
- `core/api_service.py`: `preview_callback`이 주어지고 txt2img면 `generate-image-stream` 호출. SSE `data:` 라인 파싱 → intermediate 프레임은 콜백 전달, final 프레임 바이트 반환 (`_stream_nai_request`)
- `core/headless_generation_service.py`: `execute_request`가 preview/progress 콜백을 `call_generation_api`로 전달
- `app/backend/server/generation_runner.py`: 옵션 ON + NAI일 때 스레드-안전 프리뷰 콜백 생성(`run_coroutine_threadsafe`)하여 연결
- `app/backend/server/websocket_broadcast.py`: `broadcast_preview_image` 추가 (`nai_preview_meta` 메타 + 바이너리)
- `core/headless_remote_state_service.py`: `nai_streaming_preview` 옵션 기본값 추가

**프론트엔드**
- `app/web/remote/index.html`: `NAI Stream` 옵션 토글 추가
- `app/web/remote/app.js`: 옵션 배선 등록 + `nai_preview_meta` 핸들러 + `handleWsBlob`에서 중간 프레임은 뷰어 표시만(히스토리/완료/통계 처리 제외)

## 테스트
- 변경 Python 파일 컴파일, `app.js` `node --check` 통과
- headless 서버 부팅(포트 7243 LISTEN) 확인
- 신규 심볼/시그니처 import 확인