### PR TITLE
Add discoverable history multiselect controls

### DIFF
--- a/app/backend/server/result_display_routes.py
+++ b/app/backend/server/result_display_routes.py
@@ -22,6 +22,7 @@ from core.web_session_context import WebSessionContext
 
 
 IMAGE_VIEWER_EXTENSIONS = {".png", ".webp", ".jpg", ".jpeg"}
+SELECTED_HISTORY_MAX_ITEMS = 200
 PROMPT_SOURCE_KEYS = ("general", "character", "copyright", "artist", "meta", "prompt", "input", "tags")
 AsyncRunner = Callable[..., Awaitable[Any]]
 JsonBroadcaster = Callable[[set[Any], dict[str, Any]], Awaitable[None]]
@@ -60,6 +61,41 @@ def history_item_from_action_payload(context: WebSessionContext, payload: dict[s
     if not rel_path:
         return None
     return history_item_from_viewer_path(context, rel_path)
+
+
+def _selected_history_items(
+    context: WebSessionContext,
+    paths: Any,
+) -> tuple[list[tuple[str, Any]], list[dict[str, str]], int | None]:
+    """Resolve a bounded, de-duplicated list of in-memory history paths."""
+    if not isinstance(paths, list) or not paths:
+        return [], [{"path": "", "error": "Select at least one history item"}], 400
+    if len(paths) > SELECTED_HISTORY_MAX_ITEMS:
+        return [], [{
+            "path": "",
+            "error": f"At most {SELECTED_HISTORY_MAX_ITEMS} history items can be changed at once",
+        }], 413
+
+    requested: list[tuple[str, Any]] = []
+    failures: list[dict[str, str]] = []
+    seen_paths: set[str] = set()
+    for raw_path in paths:
+        rel_path = str(raw_path or "").replace("\\", "/").strip()
+        if rel_path in seen_paths:
+            continue
+        seen_paths.add(rel_path)
+        normalized = rel_path.strip("/")
+        prefix = "__history_item__/"
+        history_id = normalized[len(prefix):] if normalized.startswith(prefix) else ""
+        if not history_id or "/" in history_id or history_id in {".", ".."}:
+            failures.append({"path": rel_path, "error": "invalid history path"})
+            continue
+        item = history_item_from_viewer_path(context, normalized)
+        if item is None:
+            failures.append({"path": normalized, "error": "history item not found"})
+            continue
+        requested.append((normalized, item))
+    return requested, failures, None
 
 
 def _request_host(value: str) -> str:
@@ -1013,6 +1049,98 @@ def register_result_display_routes(
             media_type="application/zip",
             headers={"Content-Disposition": result_images.download_content_disposition(filename)},
         )
+
+    @app.post("/api/history/selected/save")
+    async def api_history_selected_save(req: Request):
+        try:
+            payload = await req.json()
+        except Exception:
+            payload = {}
+        paths = payload.get("paths") if isinstance(payload, dict) else None
+        requested, failures, status_code = _selected_history_items(session_context, paths)
+        if status_code is not None:
+            return JSONResponse({"ok": False, "error": failures[0]["error"], "failed": failures}, status_code=status_code)
+        if not requested:
+            return JSONResponse({
+                "ok": False,
+                "error": failures[0]["error"] if failures else "History item not found",
+                "failed": failures,
+            }, status_code=404)
+        try:
+            result = await run_in_thread(
+                session_context.save_history_items,
+                [item for _, item in requested],
+                save_as_webp=True,
+                same_directory=True,
+            )
+        except Exception as exc:
+            return JSONResponse({"ok": False, "error": str(exc)}, status_code=500)
+        service_failures = list(result.get("failed") or [])
+        all_failures = [*failures, *service_failures]
+        await broadcast_json(clients, session_context.auto_save_state_payload())
+        return {
+            "ok": bool(result.get("saved")),
+            **result,
+            "failed": all_failures,
+            "requested": len(requested),
+        }
+
+    @app.post("/api/history/selected/delete")
+    async def api_history_selected_delete(req: Request):
+        try:
+            payload = await req.json()
+        except Exception:
+            payload = {}
+        paths = payload.get("paths") if isinstance(payload, dict) else None
+        requested, failures, status_code = _selected_history_items(session_context, paths)
+        if status_code is not None:
+            return JSONResponse({"ok": False, "error": failures[0]["error"], "failed": failures}, status_code=status_code)
+        if not requested:
+            return JSONResponse({
+                "ok": False,
+                "error": failures[0]["error"] if failures else "History item not found",
+                "failed": failures,
+            }, status_code=404)
+        keep_file = bool(payload.get("keep_file")) if isinstance(payload, dict) else False
+
+        def _delete_items():
+            removed_payloads: list[dict[str, Any]] = []
+            delete_failures = list(failures)
+            for rel_path, item in requested:
+                file_path = str(getattr(item, "filepath", "") or "")
+                deleted_file = False
+                try:
+                    if file_path and not keep_file:
+                        target = Path(file_path)
+                        if target.is_file():
+                            if not _move_to_trash(target):
+                                raise OSError(f"Could not move file to recycle bin: {target}")
+                            deleted_file = True
+                    removed = session_context.result_store.remove_item(item)
+                    if removed is None:
+                        raise FileNotFoundError("History item not found")
+                    removed_payloads.append({
+                        **session_context.result_store.viewer_removed_payload(removed),
+                        "file_path": file_path,
+                        "deleted_file": deleted_file,
+                        "trashed": deleted_file,
+                    })
+                except Exception as exc:
+                    delete_failures.append({"path": rel_path, "error": str(exc)})
+            return removed_payloads, delete_failures
+
+        removed_payloads, delete_failures = await run_in_thread(_delete_items)
+        for removed_payload in removed_payloads:
+            await broadcast_json(clients, removed_payload)
+        await broadcast_json(clients, session_context.auto_save_state_payload())
+        return {
+            "ok": bool(removed_payloads),
+            "deleted": len(removed_payloads),
+            "failed": delete_failures,
+            "removed": removed_payloads,
+            "total": session_context.result_store.history_total(),
+            "remaining": session_context.result_store.unsaved_history_count(),
+        }
 
     @app.get("/api/history/{kind}/{history_id}")
     async def api_history_dynamic_kind(kind: str, history_id: str, size: int = 0, full: bool = False):

--- a/app/web/remote/app.js
+++ b/app/web/remote/app.js
@@ -629,7 +629,7 @@ const resultInfoResizerReady = import('./js/features/resultInfoResizer.mjs')
   .catch(error => {
     console.error('Failed to initialize result info resizer module', error);
   });
-const resultHistoryReady = import('./js/features/resultHistory.mjs?v=20260531-imgdel3')
+const resultHistoryReady = import('./js/features/resultHistory.mjs?v=20260715-multiselect7')
   .then(({createResultHistoryController}) => {
     resultHistory = createResultHistoryController({
       document,
@@ -641,6 +641,7 @@ const resultHistoryReady = import('./js/features/resultHistory.mjs?v=20260531-im
       resultInfoContent,
       escHtml,
       showToast,
+      confirmDialog: showConfirmDialog,
       renderPromptInfoHtml,
       onPromptInfoTagLookup: lookupPromptInfoTag,
       onDiskImageSelected: onResultHistorySelectionChanged,

--- a/app/web/remote/app.js
+++ b/app/web/remote/app.js
@@ -629,7 +629,7 @@ const resultInfoResizerReady = import('./js/features/resultInfoResizer.mjs')
   .catch(error => {
     console.error('Failed to initialize result info resizer module', error);
   });
-const resultHistoryReady = import('./js/features/resultHistory.mjs?v=20260715-multiselect7')
+const resultHistoryReady = import('./js/features/resultHistory.mjs?v=20260721-multiselect-visible1')
   .then(({createResultHistoryController}) => {
     resultHistory = createResultHistoryController({
       document,

--- a/app/web/remote/index.html
+++ b/app/web/remote/index.html
@@ -6,7 +6,7 @@
 <title>NAIA Remote</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;500&family=Outfit:wght@300;400;600;700&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="style.css?v=20260718-fix3">
+<link rel="stylesheet" href="style.css?v=20260721-v2033-history-multiselect">
 </head>
 <body>
 <div class="gen-progress" id="genProgress"><div class="gen-progress-bar" id="genProgressBar"></div><div class="gen-progress-bar2" id="genProgressBar2"></div></div>
@@ -1183,6 +1183,6 @@ function openInSystemBrowser() {
   popup?.focus?.();
 }
 </script>
-<script src="app.js?v=20260718-fix4"></script>
+<script src="app.js?v=20260721-v2033-history-multiselect"></script>
 </body>
 </html>

--- a/app/web/remote/index.html
+++ b/app/web/remote/index.html
@@ -6,7 +6,7 @@
 <title>NAIA Remote</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;500&family=Outfit:wght@300;400;600;700&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="style.css?v=20260721-v2033-history-multiselect">
+<link rel="stylesheet" href="style.css?v=20260721-v2033-history-visible1">
 </head>
 <body>
 <div class="gen-progress" id="genProgress"><div class="gen-progress-bar" id="genProgressBar"></div><div class="gen-progress-bar2" id="genProgressBar2"></div></div>
@@ -1183,6 +1183,6 @@ function openInSystemBrowser() {
   popup?.focus?.();
 }
 </script>
-<script src="app.js?v=20260721-v2033-history-multiselect"></script>
+<script src="app.js?v=20260721-v2033-history-visible1"></script>
 </body>
 </html>

--- a/app/web/remote/js/features/resultHistory.mjs
+++ b/app/web/remote/js/features/resultHistory.mjs
@@ -1,4 +1,6 @@
 const HISTORY_RAIL_COLLAPSED_KEY = 'naia_history_rail_collapsed';
+const HISTORY_DELETE_MODE_KEY = 'naia_result_delete_mode';
+const HISTORY_SELECTION_MAX_ITEMS = 200;
 const PROMPT_CACHE_MAX = 80;
 const HISTORY_ITEM_PREFIX = '__history_item__/';
 
@@ -52,6 +54,7 @@ export function createResultHistoryController({
   resultInfoContent,
   escHtml,
   showToast,
+  confirmDialog = null,
   renderPromptInfoHtml = null,
   onPromptInfoTagLookup = null,
   onDiskImageSelected = () => {},
@@ -80,6 +83,370 @@ export function createResultHistoryController({
   let latestImagePath = '';
   let promptFloatCache = {};
   let promptFloatCacheKeys = [];
+  const selectedPaths = new Set();
+  let selectionAnchorPath = '';
+  let selectionBusy = false;
+  let dragSelection = null;
+  let suppressThumbClickUntil = 0;
+
+  function isEditableTarget(target) {
+    const editable = target?.closest?.('input, textarea, select, [contenteditable]:not([contenteditable="false"])');
+    return Boolean(editable);
+  }
+
+  function gridPaths(grid) {
+    if (!grid) return [];
+    return [...grid.querySelectorAll('.viewer-thumb[data-path]')]
+      .map(thumb => thumb.dataset.path || '')
+      .filter(Boolean);
+  }
+
+  function activeSelectionGrid() {
+    return viewerPopupOpen ? getEl('vpGrid') : viewerGrid;
+  }
+
+  function orderedSelectedPaths() {
+    const result = [];
+    const seen = new Set();
+    for (const grid of [activeSelectionGrid(), viewerGrid, getEl('vpGrid')]) {
+      for (const path of gridPaths(grid)) {
+        if (selectedPaths.has(path) && !seen.has(path)) {
+          result.push(path);
+          seen.add(path);
+        }
+      }
+    }
+    for (const path of selectedPaths) {
+      if (!seen.has(path)) result.push(path);
+    }
+    return result;
+  }
+
+  function selectionBarMarkup(scope) {
+    return `
+      <div class="history-selection-count" data-history-selection-count>0개 선택됨</div>
+      <div class="history-selection-actions">
+        <button type="button" class="history-selection-btn save" data-history-selection-action="save">WebP 저장 (0)</button>
+        <button type="button" class="history-selection-btn delete" data-history-selection-action="delete">선택 삭제 (0)</button>
+      </div>
+      <button type="button" class="history-selection-clear" data-history-selection-action="clear" aria-label="선택 해제" title="선택 해제">×</button>
+      <span class="history-selection-scope">${scope}</span>`;
+  }
+
+  function bindSelectionBar(bar) {
+    if (!bar || bar.dataset.bound === '1') return;
+    bar.dataset.bound = '1';
+    bar.addEventListener('click', event => {
+      const button = event.target.closest('[data-history-selection-action]');
+      if (!button) return;
+      const action = button.dataset.historySelectionAction;
+      if (action === 'save') saveSelected();
+      else if (action === 'delete') deleteSelected();
+      else if (action === 'clear') clearSelection();
+    });
+  }
+
+  function ensureRailSelectionBar() {
+    if (!viewerPanel) return null;
+    let bar = getEl('viewerSelectionBar');
+    if (!bar) {
+      bar = document.createElement('div');
+      bar.id = 'viewerSelectionBar';
+      bar.className = 'history-selection-bar viewer-panel-selection hidden';
+      bar.innerHTML = selectionBarMarkup('');
+      const header = viewerPanel.querySelector('.viewer-panel-header');
+      if (header) header.insertAdjacentElement('afterend', bar);
+      else viewerPanel.prepend(bar);
+    }
+    bindSelectionBar(bar);
+    return bar;
+  }
+
+  function updateSelectionUi() {
+    const count = selectedPaths.size;
+    document.querySelectorAll('.viewer-thumb[data-path]').forEach(thumb => {
+      const selected = selectedPaths.has(thumb.dataset.path || '');
+      thumb.classList.toggle('selected', selected);
+      thumb.setAttribute('aria-selected', selected ? 'true' : 'false');
+    });
+    document.querySelectorAll('.history-selection-bar').forEach(bar => {
+      // 드래그 도중 막대가 나타나거나 사라지면 그리드가 움직여 선택 좌표가 달라진다.
+      if (!dragSelection?.active) bar.classList.toggle('hidden', count === 0);
+      const countEl = bar.querySelector('[data-history-selection-count]');
+      if (countEl) countEl.textContent = `${count}개 선택됨`;
+      const save = bar.querySelector('[data-history-selection-action="save"]');
+      const remove = bar.querySelector('[data-history-selection-action="delete"]');
+      if (save) {
+        save.textContent = `WebP 저장 (${count})`;
+        save.disabled = selectionBusy || count === 0;
+      }
+      if (remove) {
+        remove.textContent = `선택 삭제 (${count})`;
+        remove.disabled = selectionBusy || count === 0;
+      }
+    });
+    if (viewerPanel) viewerPanel.classList.toggle('has-history-selection', count > 0);
+  }
+
+  function clearSelection() {
+    selectedPaths.clear();
+    selectionAnchorPath = '';
+    updateSelectionUi();
+  }
+
+  function selectRange(relPath, grid) {
+    const paths = gridPaths(grid);
+    const currentIndex = paths.indexOf(relPath);
+    const anchorIndex = paths.indexOf(selectionAnchorPath);
+    if (currentIndex < 0 || anchorIndex < 0) {
+      selectedPaths.add(relPath);
+      selectionAnchorPath = relPath;
+    } else {
+      const start = Math.min(currentIndex, anchorIndex);
+      const end = Math.max(currentIndex, anchorIndex);
+      paths.slice(start, end + 1).forEach(path => selectedPaths.add(path));
+    }
+    updateSelectionUi();
+  }
+
+  function handleThumbClick(event, relPath, grid, openImage, {selectOnOpen = false} = {}) {
+    const additive = Boolean(event.metaKey || event.ctrlKey);
+    if (additive || event.shiftKey) {
+      event.preventDefault();
+      event.stopPropagation();
+      if (event.shiftKey) {
+        selectRange(relPath, grid);
+      } else {
+        if (selectedPaths.has(relPath)) selectedPaths.delete(relPath);
+        else selectedPaths.add(relPath);
+        selectionAnchorPath = relPath;
+        updateSelectionUi();
+      }
+      return;
+    }
+    const hadSelection = selectedPaths.size > 0;
+    if (hadSelection) selectedPaths.clear();
+    if (selectOnOpen) selectedPaths.add(relPath);
+    selectionAnchorPath = relPath;
+    if (hadSelection || selectOnOpen) updateSelectionUi();
+    openImage();
+  }
+
+  function configureThumb(img, relPath, grid, openImage, options = {}) {
+    img.draggable = false;
+    img.setAttribute('role', 'option');
+    img.setAttribute('aria-selected', selectedPaths.has(relPath) ? 'true' : 'false');
+    img.classList.toggle('selected', selectedPaths.has(relPath));
+    img.addEventListener('dragstart', event => event.preventDefault());
+    img.onclick = event => {
+      if (Date.now() < suppressThumbClickUntil) {
+        event.preventDefault();
+        event.stopPropagation();
+        return;
+      }
+      grid.focus({preventScroll: true});
+      handleThumbClick(event, relPath, grid, openImage, options);
+    };
+  }
+
+  function endDragSelection(event) {
+    if (!dragSelection || (event && event.pointerId !== dragSelection.pointerId)) return;
+    const completedSelection = dragSelection.active;
+    const clearFromBlankClick = !completedSelection && !dragSelection.startedOnThumb;
+    dragSelection.grid.classList.remove('is-selecting');
+    dragSelection.marquee?.remove();
+    if (completedSelection && dragSelection.lastPath) selectionAnchorPath = dragSelection.lastPath;
+    if (completedSelection) suppressThumbClickUntil = Date.now() + 300;
+    dragSelection = null;
+    if (clearFromBlankClick) clearSelection();
+    else if (completedSelection) updateSelectionUi();
+  }
+
+  function marqueeBounds(startX, startY, currentX, currentY) {
+    const left = Math.min(startX, currentX);
+    const top = Math.min(startY, currentY);
+    const right = Math.max(startX, currentX);
+    const bottom = Math.max(startY, currentY);
+    return {left, top, right, bottom, width: right - left, height: bottom - top};
+  }
+
+  function rectsIntersect(a, b) {
+    return a.left < b.right && a.right > b.left && a.top < b.bottom && a.bottom > b.top;
+  }
+
+  function clampMarqueeToGrid(bounds, grid) {
+    const gridRect = grid.getBoundingClientRect();
+    const left = Math.max(bounds.left, gridRect.left);
+    const top = Math.max(bounds.top, gridRect.top);
+    const right = Math.min(bounds.right, gridRect.right);
+    const bottom = Math.min(bounds.bottom, gridRect.bottom);
+    return {
+      left,
+      top,
+      right: Math.max(left, right),
+      bottom: Math.max(top, bottom),
+      width: Math.max(0, right - left),
+      height: Math.max(0, bottom - top),
+    };
+  }
+
+  function bindDragSelection(grid) {
+    if (!grid || grid.dataset.historyDragBound === '1') return;
+    grid.dataset.historyDragBound = '1';
+    if (!grid.hasAttribute('tabindex')) grid.tabIndex = 0;
+    grid.addEventListener('pointerdown', event => {
+      if (event.button !== 0) return;
+      const thumb = event.target?.closest?.('.viewer-thumb[data-path]');
+      if (event.target !== grid && (!thumb || !grid.contains(thumb))) return;
+      grid.focus({preventScroll: true});
+      const additive = Boolean(event.metaKey || event.ctrlKey);
+      dragSelection = {
+        grid,
+        pointerId: event.pointerId,
+        startX: event.clientX,
+        startY: event.clientY,
+        basePaths: additive ? new Set(selectedPaths) : new Set(),
+        additive,
+        startedOnThumb: Boolean(thumb),
+        active: false,
+        marquee: null,
+        lastPath: '',
+      };
+      // 썸네일의 일반 클릭은 원래 상세 미리보기 이벤트까지 전달되어야 한다.
+      // 빈 공간은 브라우저 기본 선택만 막고, 포인터 캡처는 실제 드래그가 시작될 때 건다.
+      if (!thumb) event.preventDefault();
+    });
+    grid.addEventListener('pointermove', event => {
+      if (!dragSelection || dragSelection.grid !== grid || event.pointerId !== dragSelection.pointerId) return;
+      const deltaX = event.clientX - dragSelection.startX;
+      const deltaY = event.clientY - dragSelection.startY;
+      if (!dragSelection.active && Math.hypot(deltaX, deltaY) < 6) {
+        event.preventDefault();
+        return;
+      }
+      if (!dragSelection.active) {
+        dragSelection.active = true;
+        try { grid.setPointerCapture(event.pointerId); } catch (_) {}
+        dragSelection.marquee = document.createElement('div');
+        dragSelection.marquee.className = 'history-selection-marquee';
+        document.body.appendChild(dragSelection.marquee);
+        grid.classList.add('is-selecting');
+        if (!dragSelection.additive) selectedPaths.clear();
+      }
+      const bounds = clampMarqueeToGrid(marqueeBounds(
+        dragSelection.startX,
+        dragSelection.startY,
+        event.clientX,
+        event.clientY,
+      ), grid);
+      Object.assign(dragSelection.marquee.style, {
+        left: `${bounds.left}px`,
+        top: `${bounds.top}px`,
+        width: `${bounds.width}px`,
+        height: `${bounds.height}px`,
+      });
+      selectedPaths.clear();
+      dragSelection.basePaths.forEach(path => selectedPaths.add(path));
+      let lastPath = '';
+      grid.querySelectorAll('.viewer-thumb[data-path]').forEach(thumb => {
+        if (rectsIntersect(bounds, thumb.getBoundingClientRect())) {
+          const path = thumb.dataset.path || '';
+          if (path) {
+            selectedPaths.add(path);
+            lastPath = path;
+          }
+        }
+      });
+      dragSelection.lastPath = lastPath;
+      updateSelectionUi();
+      event.preventDefault();
+    });
+    grid.addEventListener('pointerup', endDragSelection);
+    grid.addEventListener('pointercancel', endDragSelection);
+  }
+
+  function selectAllLoaded() {
+    const paths = gridPaths(activeSelectionGrid());
+    paths.forEach(path => selectedPaths.add(path));
+    if (paths.length) selectionAnchorPath = paths[paths.length - 1];
+    updateSelectionUi();
+  }
+
+  function setSelectionBusy(busy) {
+    selectionBusy = Boolean(busy);
+    updateSelectionUi();
+  }
+
+  async function saveSelected() {
+    const paths = orderedSelectedPaths();
+    if (!paths.length || selectionBusy) return;
+    if (paths.length > HISTORY_SELECTION_MAX_ITEMS) {
+      showToast(`한 번에 최대 ${HISTORY_SELECTION_MAX_ITEMS}개까지 저장할 수 있습니다.`, 'error');
+      return;
+    }
+    setSelectionBusy(true);
+    try {
+      const response = await fetch('/api/history/selected/save', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({paths}),
+      });
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok || !data.ok) {
+        throw new Error(data.error || `선택 저장 실패 (${response.status})`);
+      }
+      const saved = Number(data.saved || 0);
+      const failed = Array.isArray(data.failed) ? data.failed.length : 0;
+      const folder = String(data.current_save_directory || '현재 결과 폴더');
+      showToast(`WebP 저장 완료: ${saved}개${failed ? `, 실패 ${failed}개` : ''} · ${folder}`, failed ? 'warning' : 'success');
+    } catch (error) {
+      showToast(error.message || '선택 WebP 저장 실패', 'error');
+    } finally {
+      setSelectionBusy(false);
+    }
+  }
+
+  async function deleteSelected() {
+    const paths = orderedSelectedPaths();
+    if (!paths.length || selectionBusy) return;
+    let deleteMode = 'history';
+    try { deleteMode = localStorage.getItem(HISTORY_DELETE_MODE_KEY) === 'disk' ? 'disk' : 'history'; } catch (_) {}
+    const modeText = deleteMode === 'disk'
+      ? '연결된 저장 파일은 영구 삭제하지 않고 휴지통으로 이동합니다.'
+      : '히스토리에서만 제거하며 저장 파일은 유지합니다.';
+    const message = `${paths.length}개 선택 항목을 삭제할까요?\n${modeText}`;
+    const confirmed = typeof confirmDialog === 'function'
+      ? await confirmDialog(message, {title: '선택 항목 삭제', okText: `삭제 (${paths.length})`, cancelText: '취소'})
+      : window.confirm(message);
+    if (!confirmed) return;
+
+    setSelectionBusy(true);
+    let succeeded = 0;
+    let failed = 0;
+    try {
+      const response = await fetch('/api/history/selected/delete', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({paths, keep_file: deleteMode !== 'disk'}),
+      });
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok || !data.ok) throw new Error(data.error || `HTTP ${response.status}`);
+      const removed = Array.isArray(data.removed) ? data.removed : [];
+      removed.forEach(item => {
+        selectedPaths.delete(item.rel_path || '');
+        onRemoved(item);
+      });
+      succeeded = Number(data.deleted || removed.length || 0);
+      failed = Array.isArray(data.failed) ? data.failed.length : 0;
+    } catch (error) {
+      console.error('Selected history delete failed:', error);
+      failed = paths.length;
+    }
+    if (!selectedPaths.size) selectionAnchorPath = '';
+    setSelectionBusy(false);
+    const level = failed ? (succeeded ? 'warning' : 'error') : 'success';
+    showToast(`선택 삭제 완료: 성공 ${succeeded}개, 실패 ${failed}개`, level);
+  }
 
   function setRailCollapsed(collapsed, persist = true) {
     if (!viewerPanel) return;
@@ -147,7 +514,7 @@ export function createResultHistoryController({
     img.loading = 'lazy';
     img.dataset.path = relPath;
     img.src = historyAssetUrl(relPath, 'thumb');
-    img.onclick = () => thumbClick(relPath);
+    configureThumb(img, relPath, viewerGrid, () => thumbClick(relPath));
     viewerGrid.appendChild(img);
   }
 
@@ -158,7 +525,7 @@ export function createResultHistoryController({
     img.loading = 'lazy';
     img.dataset.path = relPath;
     img.src = historyAssetUrl(relPath, 'thumb');
-    img.onclick = () => thumbClick(relPath);
+    configureThumb(img, relPath, viewerGrid, () => thumbClick(relPath));
     viewerGrid.prepend(img);
   }
 
@@ -186,6 +553,7 @@ export function createResultHistoryController({
 
   function initViewer() {
     if (!viewerGrid) return;
+    clearSelection();
     viewerPage = 0;
     viewerTotal = 0;
     viewerGrid.innerHTML = '';
@@ -461,7 +829,7 @@ export function createResultHistoryController({
         img.loading = 'lazy';
         img.dataset.path = message.rel_path;
         img.src = historyAssetUrl(message.rel_path, 'thumb');
-        img.onclick = () => selectPopupImage(message.rel_path, img);
+        configureThumb(img, message.rel_path, vpGrid, () => selectPopupImage(message.rel_path, img), {selectOnOpen: true});
         vpGrid.prepend(img);
       }
       const count = getEl('vpCount');
@@ -472,6 +840,8 @@ export function createResultHistoryController({
   function onRemoved(message) {
     const relPath = message?.rel_path || '';
     if (!relPath) return;
+    selectedPaths.delete(relPath);
+    if (selectionAnchorPath === relPath) selectionAnchorPath = '';
     // 삭제된 항목의 캐시 잔여까지 제거 (지워지면 남은 데이터가 없어야 한다).
     if (relPath in promptFloatCache) {
       delete promptFloatCache[relPath];
@@ -502,9 +872,11 @@ export function createResultHistoryController({
     const count = getEl('vpCount');
     if (count) count.textContent = viewerTotal;
     if (viewerTotal <= 0) hideLatestBadge();
+    updateSelectionUi();
   }
 
   function onCleared(message = {}) {
+    clearSelection();
     viewerPage = 0;
     viewerTotal = 0;
     viewerNavPaths = [];
@@ -540,6 +912,9 @@ export function createResultHistoryController({
         <span class="viewer-panel-title">History <span id="vpCount">${viewerTotal}</span></span>
         <button class="history-close" onclick="closeViewerPopup()">&times;</button>
       </div>
+      <div class="history-selection-bar viewer-popup-selection hidden" id="vpSelectionBar">
+        ${selectionBarMarkup('')}
+      </div>
       <div class="viewer-popup-body">
         <div class="viewer-popup-left" id="vpGrid"></div>
         <div class="viewer-popup-right" id="vpRight">
@@ -558,7 +933,12 @@ export function createResultHistoryController({
     vpPage = 0;
     loadPopupPage(0);
     const grid = getEl('vpGrid');
-    if (grid) grid.addEventListener('scroll', popupScroll);
+    if (grid) {
+      grid.addEventListener('scroll', popupScroll);
+      bindDragSelection(grid);
+    }
+    bindSelectionBar(getEl('vpSelectionBar'));
+    updateSelectionUi();
   }
 
   async function loadPopupPage(page) {
@@ -578,7 +958,7 @@ export function createResultHistoryController({
           img.loading = 'lazy';
           img.dataset.path = entry.rel_path;
           img.src = historyAssetUrl(entry.rel_path, 'thumb');
-          img.onclick = () => selectPopupImage(entry.rel_path, img);
+          configureThumb(img, entry.rel_path, grid, () => selectPopupImage(entry.rel_path, img), {selectOnOpen: true});
           grid.appendChild(img);
         }
       }
@@ -664,8 +1044,37 @@ export function createResultHistoryController({
 
   function bindKeyboard() {
     document.addEventListener('keydown', event => {
-      const tag = (event.target.tagName || '').toLowerCase();
-      if (tag === 'input' || tag === 'textarea' || tag === 'select') return;
+      if (isEditableTarget(event.target)) return;
+
+      const commandKey = Boolean(event.metaKey || event.ctrlKey);
+      const key = String(event.key || '').toLowerCase();
+      const activeElement = document.activeElement;
+      const historyFocused = Boolean(
+        viewerPopupOpen
+        || selectedPaths.size
+        || viewerPanel?.contains(activeElement)
+        || getEl('viewerLightbox')?.contains(activeElement)
+      );
+      if (commandKey && key === 'a' && historyFocused) {
+        event.preventDefault();
+        selectAllLoaded();
+        return;
+      }
+      if (commandKey && key === 's' && selectedPaths.size) {
+        event.preventDefault();
+        saveSelected();
+        return;
+      }
+      if ((event.key === 'Delete' || event.key === 'Backspace') && selectedPaths.size) {
+        event.preventDefault();
+        deleteSelected();
+        return;
+      }
+      if (event.key === 'Escape' && selectedPaths.size) {
+        event.preventDefault();
+        clearSelection();
+        return;
+      }
 
       if (viewerPopupOpen) {
         if (event.key === 'ArrowUp' || event.key === 'ArrowLeft') {
@@ -710,9 +1119,12 @@ export function createResultHistoryController({
   function init() {
     if (initialized) return;
     initialized = true;
+    ensureRailSelectionBar();
     initRail();
     bindInfiniteScroll();
+    bindDragSelection(viewerGrid);
     bindKeyboard();
+    updateSelectionUi();
   }
 
   return {

--- a/app/web/remote/js/features/resultHistory.mjs
+++ b/app/web/remote/js/features/resultHistory.mjs
@@ -124,7 +124,7 @@ export function createResultHistoryController({
 
   function selectionBarMarkup(scope) {
     return `
-      <div class="history-selection-count" data-history-selection-count>0개 선택됨</div>
+      <div class="history-selection-count" data-history-selection-count>다중 선택 · 0개 선택됨</div>
       <div class="history-selection-actions">
         <button type="button" class="history-selection-btn save" data-history-selection-action="save">WebP 저장 (0)</button>
         <button type="button" class="history-selection-btn delete" data-history-selection-action="delete">선택 삭제 (0)</button>
@@ -152,8 +152,8 @@ export function createResultHistoryController({
     if (!bar) {
       bar = document.createElement('div');
       bar.id = 'viewerSelectionBar';
-      bar.className = 'history-selection-bar viewer-panel-selection hidden';
-      bar.innerHTML = selectionBarMarkup('');
+      bar.className = 'history-selection-bar viewer-panel-selection';
+      bar.innerHTML = selectionBarMarkup('Cmd/Ctrl · Shift · 드래그 · Cmd/Ctrl+A · Esc');
       const header = viewerPanel.querySelector('.viewer-panel-header');
       if (header) header.insertAdjacentElement('afterend', bar);
       else viewerPanel.prepend(bar);
@@ -170,12 +170,11 @@ export function createResultHistoryController({
       thumb.setAttribute('aria-selected', selected ? 'true' : 'false');
     });
     document.querySelectorAll('.history-selection-bar').forEach(bar => {
-      // 드래그 도중 막대가 나타나거나 사라지면 그리드가 움직여 선택 좌표가 달라진다.
-      if (!dragSelection?.active) bar.classList.toggle('hidden', count === 0);
       const countEl = bar.querySelector('[data-history-selection-count]');
-      if (countEl) countEl.textContent = `${count}개 선택됨`;
+      if (countEl) countEl.textContent = `다중 선택 · ${count}개 선택됨`;
       const save = bar.querySelector('[data-history-selection-action="save"]');
       const remove = bar.querySelector('[data-history-selection-action="delete"]');
+      const clear = bar.querySelector('[data-history-selection-action="clear"]');
       if (save) {
         save.textContent = `WebP 저장 (${count})`;
         save.disabled = selectionBusy || count === 0;
@@ -184,6 +183,7 @@ export function createResultHistoryController({
         remove.textContent = `선택 삭제 (${count})`;
         remove.disabled = selectionBusy || count === 0;
       }
+      if (clear) clear.disabled = selectionBusy || count === 0;
     });
     if (viewerPanel) viewerPanel.classList.toggle('has-history-selection', count > 0);
   }
@@ -912,8 +912,8 @@ export function createResultHistoryController({
         <span class="viewer-panel-title">History <span id="vpCount">${viewerTotal}</span></span>
         <button class="history-close" onclick="closeViewerPopup()">&times;</button>
       </div>
-      <div class="history-selection-bar viewer-popup-selection hidden" id="vpSelectionBar">
-        ${selectionBarMarkup('')}
+      <div class="history-selection-bar viewer-popup-selection" id="vpSelectionBar">
+        ${selectionBarMarkup('Cmd/Ctrl · Shift · 드래그 · Cmd/Ctrl+A · Esc')}
       </div>
       <div class="viewer-popup-body">
         <div class="viewer-popup-left" id="vpGrid"></div>

--- a/app/web/remote/style.css
+++ b/app/web/remote/style.css
@@ -7009,6 +7009,18 @@ body.resizing-result-info {
   gap: 6px;
   align-content: start;
 }
+.viewer-panel-grid,
+.viewer-popup-left,
+.viewer-thumb {
+  user-select: none;
+  -webkit-user-select: none;
+  -webkit-user-drag: none;
+}
+.viewer-panel-grid:focus,
+.viewer-popup-left:focus,
+.viewer-thumb:focus {
+  outline: none;
+}
 .viewer-panel-grid::-webkit-scrollbar { width: 3px; }
 .viewer-panel-grid::-webkit-scrollbar-thumb { background: var(--border-dim); border-radius: 2px; }
 .viewer-thumb {
@@ -7023,6 +7035,96 @@ body.resizing-result-info {
 }
 .viewer-thumb:hover { opacity: 1; }
 .viewer-thumb.active { opacity: 1; border: 2px solid var(--accent); box-shadow: 0 0 8px rgba(124,106,239,0.3); }
+.viewer-thumb.selected {
+  opacity: 1;
+  outline: 3px solid #7ee7b8;
+  outline-offset: -3px;
+  box-shadow: 0 0 0 1px rgba(8,18,15,0.95), 0 0 12px rgba(126,231,184,0.58);
+  filter: saturate(1.08) brightness(1.08);
+}
+.viewer-thumb.active.selected {
+  border-color: var(--accent);
+  outline-color: #7ee7b8;
+}
+.viewer-panel-grid.is-selecting,
+.viewer-popup-left.is-selecting {
+  cursor: crosshair;
+  user-select: none;
+  -webkit-user-select: none;
+}
+.history-selection-marquee {
+  position: fixed;
+  z-index: 10050;
+  pointer-events: none;
+  border: 1px solid rgba(126,231,184,0.95);
+  background: rgba(126,231,184,0.16);
+  box-shadow: inset 0 0 0 1px rgba(8,18,15,0.36);
+  border-radius: 2px;
+}
+
+.history-selection-bar {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 6px;
+  padding: 8px;
+  flex-shrink: 0;
+  background: rgba(45,78,67,0.2);
+  border-bottom: 1px solid rgba(126,231,184,0.3);
+}
+.history-selection-count {
+  min-width: 0;
+  padding-right: 22px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  color: #a8f2cf;
+  overflow-wrap: anywhere;
+}
+.history-selection-actions {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 5px;
+}
+.history-selection-btn {
+  min-width: 0;
+  min-height: 34px;
+  padding: 5px 4px;
+  border: 1px solid rgba(126,231,184,0.34);
+  border-radius: 6px;
+  background: rgba(126,231,184,0.09);
+  color: #baf6da;
+  font-family: var(--font-mono);
+  font-size: 9px;
+  line-height: 1.25;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  cursor: pointer;
+}
+.history-selection-btn:hover:not(:disabled) { background: rgba(126,231,184,0.18); }
+.history-selection-btn.delete {
+  border-color: rgba(255,112,112,0.34);
+  background: rgba(255,94,94,0.09);
+  color: #ffb1b1;
+}
+.history-selection-btn.delete:hover:not(:disabled) { background: rgba(255,94,94,0.18); }
+.history-selection-btn:disabled { opacity: 0.48; cursor: wait; }
+.history-selection-clear {
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+}
+.history-selection-clear:hover { color: #fff; }
+.history-selection-scope { display: none; }
 .viewer-panel-loading {
   text-align: center;
   padding: 12px;
@@ -7157,12 +7259,20 @@ body.resizing-result-info {
 .viewer-popup-header {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: 8px;
   padding: 8px 16px;
   border-bottom: 1px solid var(--border-dim);
   flex-shrink: 0;
 }
 .viewer-popup-header .viewer-panel-title { flex: 1; }
+.viewer-popup-selection {
+  grid-template-columns: minmax(120px, 1fr) minmax(220px, auto);
+  align-items: center;
+  padding: 8px 16px;
+}
+.viewer-popup-selection .history-selection-count { grid-column: 1; }
+.viewer-popup-selection .history-selection-actions { grid-column: 2; min-width: 220px; }
 .viewer-popup-body {
   flex: 1;
   display: flex;
@@ -7205,6 +7315,16 @@ body.resizing-result-info {
   position: absolute;
   bottom: 42px; left: 8px; right: 8px;
   max-width: none;
+}
+@media (max-width: 600px) {
+  .viewer-popup-selection {
+    grid-template-columns: minmax(0, 1fr);
+  }
+  .viewer-popup-selection .history-selection-count,
+  .viewer-popup-selection .history-selection-actions {
+    grid-column: 1;
+    min-width: 0;
+  }
 }
 /* ---- Prompt floating panel (reusable) ---- */
 .prompt-float {
@@ -15841,6 +15961,7 @@ body.detached-module.detached-module-img2img .mod-img2img-mask-compact-actions {
   .viewer-panel.collapsed .viewer-panel-save-row,
   .viewer-panel.collapsed .viewer-panel-title,
   .viewer-panel.collapsed .viewer-pop-btn,
+  .viewer-panel.collapsed .viewer-panel-selection,
   .viewer-panel.collapsed .viewer-panel-grid,
   .viewer-panel.collapsed .viewer-panel-loading,
   .viewer-panel.collapsed .viewer-panel-bottom {

--- a/app/web/remote/style.css
+++ b/app/web/remote/style.css
@@ -7108,7 +7108,7 @@ body.resizing-result-info {
   color: #ffb1b1;
 }
 .history-selection-btn.delete:hover:not(:disabled) { background: rgba(255,94,94,0.18); }
-.history-selection-btn:disabled { opacity: 0.48; cursor: wait; }
+.history-selection-btn:disabled { opacity: 0.48; cursor: not-allowed; }
 .history-selection-clear {
   position: absolute;
   top: 5px;
@@ -7124,7 +7124,15 @@ body.resizing-result-info {
   cursor: pointer;
 }
 .history-selection-clear:hover { color: #fff; }
-.history-selection-scope { display: none; }
+.history-selection-clear:disabled { opacity: 0.35; cursor: default; }
+.history-selection-scope {
+  display: block;
+  font-family: var(--font-mono);
+  font-size: 8px;
+  line-height: 1.35;
+  color: var(--text-dim);
+  overflow-wrap: anywhere;
+}
 .viewer-panel-loading {
   text-align: center;
   padding: 12px;
@@ -7273,6 +7281,7 @@ body.resizing-result-info {
 }
 .viewer-popup-selection .history-selection-count { grid-column: 1; }
 .viewer-popup-selection .history-selection-actions { grid-column: 2; min-width: 220px; }
+.viewer-popup-selection .history-selection-scope { grid-column: 1 / -1; }
 .viewer-popup-body {
   flex: 1;
   display: flex;

--- a/core/headless_save_service.py
+++ b/core/headless_save_service.py
@@ -177,6 +177,56 @@ class HeadlessSaveService:
             "current_save_directory": str(directory),
         }
 
+    def save_history_items(
+        self,
+        items: list[Any],
+        *,
+        save_as_webp: bool = True,
+        same_directory: bool = True,
+    ) -> dict[str, Any]:
+        """Save selected history items together in the current result folder.
+
+        Bulk selection is an explicit export action, so it can force WebP without
+        changing the user's Auto Save preference.  ``same_directory`` deliberately
+        bypasses classification subfolders so every selected image lands beside the
+        others in the one folder shown by the Save Directory module.
+        """
+        context = self.context
+        directory = self.current_save_directory()
+        directory.mkdir(parents=True, exist_ok=True)
+        saved_paths: list[str] = []
+        failed: list[dict[str, str]] = []
+        seen_ids: set[str] = set()
+
+        for item in list(items or []):
+            history_id = str(getattr(item, "history_id", "") or "")
+            if not history_id or history_id in seen_ids:
+                continue
+            seen_ids.add(history_id)
+            try:
+                target = self._save_history_item_to_directory(
+                    item,
+                    directory,
+                    save_as_webp=bool(save_as_webp),
+                    apply_classification=not bool(same_directory),
+                )
+                saved_paths.append(str(target))
+            except Exception as exc:
+                failed.append({
+                    "history_id": history_id,
+                    "error": str(exc),
+                })
+
+        return {
+            "saved": len(saved_paths),
+            "failed": failed,
+            "paths": saved_paths,
+            "format": "webp" if save_as_webp else "png",
+            "same_directory": bool(same_directory),
+            "current_save_directory": str(directory),
+            "remaining": context.result_store.unsaved_history_count(),
+        }
+
     def current_save_directory(
         self,
         base_path: str | None = None,
@@ -268,10 +318,17 @@ class HeadlessSaveService:
                     return value
         return ""
 
-    def _save_history_item_to_directory(self, item: Any, directory: Path, *, save_as_webp: bool) -> Path:
+    def _save_history_item_to_directory(
+        self,
+        item: Any,
+        directory: Path,
+        *,
+        save_as_webp: bool,
+        apply_classification: bool = True,
+    ) -> Path:
         context = self.context
         # 분류 하위 폴더(없으면 None)를 결정해 전달받은 기준 디렉터리 뒤에 붙인다.
-        subfolder = self._classification_subfolder_for_item(item)
+        subfolder = self._classification_subfolder_for_item(item) if apply_classification else None
         if subfolder:
             for part in Path(subfolder).parts:
                 directory = directory / part

--- a/core/web_session_context.py
+++ b/core/web_session_context.py
@@ -549,6 +549,19 @@ class WebSessionContext:
     def save_history_item(self, item: Any) -> dict[str, Any]:
         return self._save_service().save_history_item(item)
 
+    def save_history_items(
+        self,
+        items: list[Any],
+        *,
+        save_as_webp: bool = True,
+        same_directory: bool = True,
+    ) -> dict[str, Any]:
+        return self._save_service().save_history_items(
+            items,
+            save_as_webp=save_as_webp,
+            same_directory=same_directory,
+        )
+
     def _prompt_engineering_module_state(self) -> dict[str, Any]:
         return self._prompt_engineering_service().state()
 

--- a/release_assets/manifests/remote_web_feature_contract.json
+++ b/release_assets/manifests/remote_web_feature_contract.json
@@ -461,6 +461,8 @@
         {"method": "GET", "path": "/api/history/meta/{history_id}", "smoke": "asset_runtime"},
         {"method": "POST", "path": "/api/history/unsaved/save-all", "smoke": "state_mutation"},
         {"method": "GET", "path": "/api/history/unsaved/download", "smoke": "asset_runtime"},
+        {"method": "POST", "path": "/api/history/selected/save", "smoke": "state_mutation"},
+        {"method": "POST", "path": "/api/history/selected/delete", "smoke": "state_mutation"},
         {"method": "GET", "path": "/api/history/{kind}/{history_id}", "smoke": "asset_runtime"},
         {"method": "POST", "path": "/api/result/open-location", "smoke": "state_mutation"},
         {"method": "POST", "path": "/api/result/action/reroll", "smoke": "external_live"},

--- a/tools/result_history_drag_harness.html
+++ b/tools/result_history_drag_harness.html
@@ -1,0 +1,56 @@
+<!doctype html>
+<html lang="ko">
+<head>
+  <meta charset="utf-8">
+  <title>NAIA result history drag harness</title>
+  <link rel="stylesheet" href="../app/web/remote/style.css">
+  <style>
+    body { margin: 0; padding: 24px; background: #11141b; color: #fff; }
+    #viewerPanel { width: 420px; height: 420px; display: flex; flex-direction: column; }
+    #viewerGrid { position: relative; grid-template-columns: repeat(3, 110px); gap: 12px; }
+    .viewer-thumb { width: 110px; height: 110px; aspect-ratio: auto; background: #2b3342; }
+  </style>
+</head>
+<body>
+  <button id="openPopupHarness" type="button">Open popup</button>
+  <aside id="viewerPanel">
+    <div class="viewer-panel-header">History drag regression harness</div>
+    <div id="viewerGrid" class="viewer-panel-grid">
+      <img class="viewer-thumb" data-path="__history_item__/one" alt="one">
+      <img class="viewer-thumb" data-path="__history_item__/two" alt="two">
+      <img class="viewer-thumb" data-path="__history_item__/three" alt="three">
+      <img class="viewer-thumb" data-path="__history_item__/four" alt="four">
+      <img class="viewer-thumb" data-path="__history_item__/five" alt="five">
+      <img class="viewer-thumb" data-path="__history_item__/six" alt="six">
+    </div>
+  </aside>
+  <div id="viewerLightbox"></div>
+  <script type="module">
+    import {createResultHistoryController} from '../app/web/remote/js/features/resultHistory.mjs';
+
+    const controller = createResultHistoryController({
+      document,
+      window,
+      localStorage,
+      fetch: async url => ({
+        ok: true,
+        json: async () => String(url).includes('/api/history/list')
+          ? ({images: [
+              {rel_path: '__history_item__/one'},
+              {rel_path: '__history_item__/two'},
+            ], total: 2})
+          : ({}),
+      }),
+      preview: document.createElement('img'),
+      emptyMsg: document.createElement('div'),
+      resultInfoContent: document.createElement('div'),
+      escHtml: value => String(value),
+      showToast: () => {},
+    });
+    controller.init();
+    document.getElementById('openPopupHarness').addEventListener('click', () => controller.openPopup());
+    window.historyHarnessController = controller;
+    document.documentElement.dataset.harnessReady = '1';
+  </script>
+</body>
+</html>

--- a/tools/test_selected_history_actions.py
+++ b/tools/test_selected_history_actions.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Focused regression test for selected-history WebP save and batch delete."""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from PIL import Image
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from app.backend.server import result_display_routes  # noqa: E402
+from core.headless_result_service import HeadlessHistoryItem, HeadlessResultStore  # noqa: E402
+from core.headless_save_service import HeadlessSaveService  # noqa: E402
+
+
+def make_item(color: tuple[int, int, int]) -> HeadlessHistoryItem:
+    image = Image.new("RGB", (5, 4), color)
+    png_buffer = io.BytesIO()
+    image.save(png_buffer, format="PNG")
+    webp_buffer = io.BytesIO()
+    image.save(webp_buffer, format="WEBP", quality=85)
+    return HeadlessHistoryItem(
+        image=image,
+        raw_bytes=png_buffer.getvalue(),
+        webp_bytes=webp_buffer.getvalue(),
+        generation_params={},
+        prompt_context={},
+    )
+
+
+def build_client(store: HeadlessResultStore, save_dir: Path) -> tuple[TestClient, SimpleNamespace]:
+    app = FastAPI()
+    context = SimpleNamespace(
+        result_store=store,
+        save_directory_state={
+            "base_path": str(save_dir),
+            "use_timestamp_folder": False,
+            "save_counter": 1,
+            "filename_format": "number_only",
+            "classification_method": "none",
+            "classification_rules": "",
+        },
+        auto_save_state={"save_as_webp": False},
+        session_timestamp="test-session",
+        remote_options={},
+        save_remote_ui_state=lambda: None,
+        auto_save_state_payload=lambda: {"type": "module_state", "module_id": "auto_save"},
+        _coerce_bool=lambda value: str(value).lower() in {"1", "true", "yes", "on"} if isinstance(value, str) else bool(value),
+        _output_root=lambda: save_dir,
+    )
+    save_service = HeadlessSaveService(context)
+    context._current_save_directory = save_service.current_save_directory
+    context.save_history_items = save_service.save_history_items
+
+    async def run_in_thread(function, *args, **kwargs):
+        return function(*args, **kwargs)
+
+    async def broadcast_json(_clients, _payload):
+        return None
+
+    result_display_routes.register_result_display_routes(
+        app,
+        context,
+        run_in_thread=run_in_thread,
+        clients=set(),
+        broadcast_json=broadcast_json,
+    )
+    return TestClient(app), context
+
+
+def main() -> int:
+    evidence: dict[str, object] = {}
+    with tempfile.TemporaryDirectory(prefix="naia-selected-history-test-") as temp_dir:
+        save_dir = Path(temp_dir) / "same-result-folder"
+        store = HeadlessResultStore(max_items=10)
+        first = make_item((255, 0, 0))
+        second = make_item((0, 255, 0))
+        store._items = [first, second]
+        store._set_latest_item(first)
+
+        client, _context = build_client(store, save_dir)
+        with client:
+            saved = client.post(
+                "/api/history/selected/save",
+                json={"paths": [first.rel_path, second.rel_path]},
+            )
+            assert saved.status_code == 200, saved.text
+            saved_payload = saved.json()
+            assert saved_payload["ok"] is True, saved_payload
+            assert saved_payload["saved"] == 2, saved_payload
+            assert saved_payload["format"] == "webp", saved_payload
+            assert saved_payload["same_directory"] is True, saved_payload
+            saved_paths = [Path(value) for value in saved_payload["paths"]]
+            assert len(saved_paths) == 2
+            assert {path.parent for path in saved_paths} == {save_dir}
+            assert all(path.suffix.lower() == ".webp" for path in saved_paths)
+            for path in saved_paths:
+                with Image.open(path) as opened:
+                    assert opened.format == "WEBP"
+            evidence["webp_saved"] = len(saved_paths)
+            evidence["same_folder"] = str(save_dir)
+
+            traversal = client.post(
+                "/api/history/selected/save",
+                json={"paths": ["__history_item__/../outside.png"]},
+            )
+            assert traversal.status_code == 404, traversal.text
+            assert traversal.json()["error"] == "invalid history path"
+            evidence["path_traversal_blocked"] = True
+
+            second_path = Path(second.filepath)
+            history_only = client.post(
+                "/api/history/selected/delete",
+                json={"paths": [second.rel_path], "keep_file": True},
+            )
+            assert history_only.status_code == 200, history_only.text
+            assert history_only.json()["deleted"] == 1
+            assert second_path.is_file(), "history-only delete must retain the saved WebP"
+            assert store.get_item(second.history_id) is None
+            evidence["history_only_delete_kept_file"] = True
+
+            first_path = Path(first.filepath)
+            original_move_to_trash = result_display_routes._move_to_trash
+
+            def fake_move_to_trash(path: Path) -> bool:
+                path.unlink()
+                return True
+
+            result_display_routes._move_to_trash = fake_move_to_trash
+            try:
+                disk_delete = client.post(
+                    "/api/history/selected/delete",
+                    json={"paths": [first.rel_path], "keep_file": False},
+                )
+            finally:
+                result_display_routes._move_to_trash = original_move_to_trash
+            assert disk_delete.status_code == 200, disk_delete.text
+            assert disk_delete.json()["deleted"] == 1
+            assert disk_delete.json()["removed"][0]["trashed"] is True
+            assert not first_path.exists()
+            assert store.get_item(first.history_id) is None
+            evidence["disk_delete_uses_trash_path"] = True
+
+    print(json.dumps(evidence, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- port shared result-history multi-selection behavior to v2.0.33
- support Cmd/Ctrl-click, Shift range, marquee drag, Cmd/Ctrl+A, and Escape across the history rail and popup
- add batch WebP save plus Trash-backed delete/history-only actions while preserving original file bytes and metadata
- keep the selection controls visible when nothing is selected so the feature is discoverable

## Why
The v2.0.33 update did not include the previously completed Windows history-selection fixes, and the actions were hidden at zero selection, which made the feature look unavailable.

## Verification
- `node --check app/web/remote/js/features/resultHistory.mjs`
- `node --check app/web/remote/app.js`
- `venv/bin/python tools/test_selected_history_actions.py`
- `npm run check:feature-contract` from `app/electron` using the project Python 3.12 environment
- `git diff --check v2.0.33...HEAD`